### PR TITLE
Provide a default conference; without it you can't get at the Admin.

### DIFF
--- a/fixtures/initial_data.json
+++ b/fixtures/initial_data.json
@@ -6,5 +6,12 @@
             "domain": "localhost",
             "name": "SymposionCon"
         }
+    },
+    {
+        "pk": 1,
+        "model": "conference.conference",
+        "fields": {
+            "title": "SymposionCon"
+        }
     }
 ]


### PR DESCRIPTION
The `/admin` URI doesn't work because username logins don't work (`settings.py` only allows email logins, from `/account/login`). But `/account/login` (or anything other than `/admin` for that matter) won't load and throw a stack trace because there's no conference defined.

If the `initial_data.json` is going to have a site defined, it should probably also have a conference defined.

Thanks!
