### PR TITLE
Tiny change to make sponsor entries addressable

### DIFF
--- a/symposion/templates/sponsorship/_sponsor_link.html
+++ b/symposion/templates/sponsorship/_sponsor_link.html
@@ -2,9 +2,9 @@
 {% spaceless %}
 <a href="{{ sponsor.external_url }}">
     {% if dimensions %}
-        <img id="Sponsor{{ sponsor.id }} src="{% thumbnail sponsor.logo dimensions %}" alt="{{ sponsor.name }}" />
+        <img id="sponsor_{{ sponsor.pk }}" src="{% thumbnail sponsor.logo dimensions %}" alt="{{ sponsor.name }}" />
     {% else %}
-        <img id="Sponsor{{ sponsor.id }}" src="{% thumbnail sponsor.logo '150x150' %}" alt="{{ sponsor.name }}" />
+        <img id="sponsor_{{ sponsor.pk }}" src="{% thumbnail sponsor.logo '150x150' %}" alt="{{ sponsor.name }}" />
     {% endif %}
 </a>
 {% endspaceless %}


### PR DESCRIPTION
Just adds an id attribute to both <img> tags to allow use of fragment identifiers.
