### PR TITLE
Provides a better error message when a sponsor benefit text field is lon...

### DIFF
--- a/symposion/sponsorship/models.py
+++ b/symposion/sponsorship/models.py
@@ -194,8 +194,11 @@ class SponsorBenefit(models.Model):
         return u"%s - %s" % (self.sponsor, self.benefit)
     
     def clean(self):
-        if self.max_words and len(self.text.split()) > self.max_words:
-            raise ValidationError("Sponsorship level only allows for %s words." % self.max_words)
+        num_words = len(self.text.split())
+        if self.max_words and num_words > self.max_words:
+            raise ValidationError(
+                "Sponsorship level only allows for %s words, you provided %d." % (
+                    self.max_words, num_words))
     
     def data_fields(self):
         """


### PR DESCRIPTION
...ger than the allowed limit.

It tells you how many words you've written!
