### PR TITLE
Adds a manage.py script to assign reviewers to talks.

### DIFF
--- a/symposion/reviews/management/commands/assign_reviewers.py
+++ b/symposion/reviews/management/commands/assign_reviewers.py
@@ -1,0 +1,17 @@
+import csv
+import os
+import random
+
+from django.contrib.auth import models
+from django.core.management.base import BaseCommand
+
+from symposion.reviews.models import ReviewAssignment
+from symposion.proposals.models import ProposalBase
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        for proposal in ProposalBase.objects.filter(cancelled=0):
+            print "Creating assignments for %s" % (proposal.title,)
+            ReviewAssignment.create_assignments(proposal)


### PR DESCRIPTION
Requires that a 'reviewers' group exist, and that there are people assigned to it (otherwise it won't find any reviewers to add!).

It will assign up to 3 reviewers, where those reviewers are NOT one of the speakers, and that reviewer has not opted out of reviewing that talk. It will choose random reviewers from those with the fewest existing not-opted-out assignments.
