### PR TITLE
Redirect to dashboard if there are no benefits to edit.

### DIFF
--- a/symposion/sponsorship/views.py
+++ b/symposion/sponsorship/views.py
@@ -15,7 +15,16 @@ def sponsor_apply(request):
         form = SponsorApplicationForm(request.POST, user=request.user)
         if form.is_valid():
             sponsor = form.save()
-            return redirect("sponsor_detail", pk=sponsor.pk)
+            if sponsor.sponsor_benefits.all():
+                # Redirect user to sponsor_detail to give extra information.
+                messages.success(request, "Thank you for your sponsorship "
+                                 "application. Please update your "
+                                 "benefit details below.")
+                return redirect("sponsor_detail", pk=sponsor.pk)
+            else:
+                messages.success(request, "Thank you for your sponsorship "
+                                 "application.")
+                return redirect("dashboard")
     else:
         form = SponsorApplicationForm(user=request.user)
     


### PR DESCRIPTION
The sponsor object has been created, and we only need to collect details
about the potential-sponsor's benefits. If there are no benefits, the user
should be redirected to the dashboard rather than forced to submit what
appears to be the same form twice.
