### PR TITLE
flake8 fixes for the schedule edit form.

### DIFF
--- a/symposion/schedule/forms.py
+++ b/symposion/schedule/forms.py
@@ -1,9 +1,15 @@
+import csv
+import time
+from datetime import datetime
+
 from django import forms
+from django.contrib import messages
+from django.db import IntegrityError
 from django.db.models import Q
 
 from markitup.widgets import MarkItUpWidget
 
-from symposion.schedule.models import Presentation
+from symposion.schedule.models import (Day, Presentation, Room, SlotKind, Slot, SlotRoom)
 
 
 class SlotEditForm(forms.Form):
@@ -139,8 +145,10 @@ class ScheduleSectionForm(forms.Form):
                 )
                 created_items.append(slot)
             try:
-                with transaction.atomic():
-                    SlotRoom.objects.create(slot=slot, room=room)
+                # @@@ TODO - upgrade Django, use atomic transactions
+                # with transaction.atomic():
+                #    SlotRoom.objects.create(slot=slot, room=room)
+                SlotRoom.objects.create(slot=slot, room=room)
             except IntegrityError:
                 # delete all created objects and report error
                 for x in created_items:


### PR DESCRIPTION
The schedule edit form had missing imports and a call to a django feature not supported in django 1.4.
