### PR TITLE
Replace markdown fields with TextFields & remove unnecessary requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,5 @@
 Django>=1.7.1
 django-appconf==0.6
-django-markitup==2.2.2
 django-model-utils==2.2
 django-reversion==1.8.5
 django-sitetree==1.2.1
@@ -8,6 +7,4 @@ django-taggit==0.12.2
 django-timezones==0.2
 django-user-accounts==1.0
 easy-thumbnails==2.2
-html5lib==0.999
-markdown==2.5.2
 pytz==2014.10

--- a/symposion/boxes/models.py
+++ b/symposion/boxes/models.py
@@ -3,13 +3,13 @@ from django.contrib.auth.models import User
 
 import reversion
 
-from markitup.fields import MarkupField
+
 
 
 class Box(models.Model):
 
     label = models.CharField(max_length=100, db_index=True)
-    content = MarkupField(blank=True)
+    content = models.TextField(blank=True)
 
     created_by = models.ForeignKey(User, related_name="boxes")
     last_updated_by = models.ForeignKey(User, related_name="updated_boxes")

--- a/symposion/cms/models.py
+++ b/symposion/cms/models.py
@@ -8,8 +8,6 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from markitup.fields import MarkupField
-
 from taggit.managers import TaggableManager
 
 import reversion
@@ -26,7 +24,7 @@ class Page(models.Model):
 
     title = models.CharField(max_length=100)
     path = models.CharField(max_length=100, unique=True)
-    body = MarkupField()
+    body = models.TextField()
     status = models.IntegerField(choices=STATUS_CHOICES, default=2)
     publish_date = models.DateTimeField(default=datetime.datetime.now)
     created = models.DateTimeField(editable=False, default=datetime.datetime.now)

--- a/symposion/proposals/models.py
+++ b/symposion/proposals/models.py
@@ -11,8 +11,6 @@ from django.contrib.auth.models import User
 
 import reversion
 
-from markitup.fields import MarkupField
-
 from model_utils.managers import InheritanceManager
 
 from symposion.conference.models import Section
@@ -87,19 +85,8 @@ class ProposalBase(models.Model):
         help_text=_("If your proposal is accepted this will be made public and printed in the "
                     "program. Should be one paragraph, maximum 400 characters.")
     )
-    abstract = MarkupField(
-        _("Detailed Abstract"),
-        help_text=_("Detailed outline. Will be made public if your proposal is accepted. Edit "
-                    "using <a href='http://daringfireball.net/projects/markdown/basics' "
-                    "target='_blank'>Markdown</a>.")
-    )
-    additional_notes = MarkupField(
-        blank=True,
-        help_text=_("Anything else you'd like the program committee to know when making their "
-                    "selection: your past experience, etc. This is not made public. Edit using "
-                    "<a href='http://daringfireball.net/projects/markdown/basics' "
-                    "target='_blank'>Markdown</a>.")
-    )
+    abstract = models.TextField()
+    additional_notes = models.TextField()
     submitted = models.DateTimeField(
         default=now,
         editable=False,

--- a/symposion/reviews/models.py
+++ b/symposion/reviews/models.py
@@ -8,8 +8,6 @@ from django.db.models.signals import post_save
 
 from django.contrib.auth.models import User
 
-from markitup.fields import MarkupField
-
 from symposion.proposals.models import ProposalBase
 from symposion.schedule.models import Presentation
 
@@ -95,7 +93,7 @@ class ProposalMessage(models.Model):
     proposal = models.ForeignKey(ProposalBase, related_name="messages")
     user = models.ForeignKey(User)
 
-    message = MarkupField()
+    message = models.TextField()
     submitted_at = models.DateTimeField(default=datetime.now, editable=False)
 
     class Meta:
@@ -111,7 +109,7 @@ class Review(models.Model):
     # No way to encode "-0" vs. "+0" into an IntegerField, and I don't feel
     # like some complicated encoding system.
     vote = models.CharField(max_length=2, blank=True, choices=VOTES.CHOICES)
-    comment = MarkupField()
+    comment = models.TextField()
     submitted_at = models.DateTimeField(default=datetime.now, editable=False)
 
     def save(self, **kwargs):
@@ -283,7 +281,7 @@ class ProposalResult(models.Model):
 class Comment(models.Model):
     proposal = models.ForeignKey(ProposalBase, related_name="comments")
     commenter = models.ForeignKey(User)
-    text = MarkupField()
+    text = models.TextField()
 
     # Or perhaps more accurately, can the user see this comment.
     public = models.BooleanField(choices=[(True, "public"), (False, "private")], default=False)

--- a/symposion/schedule/models.py
+++ b/symposion/schedule/models.py
@@ -3,8 +3,6 @@ import datetime
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
-from markitup.fields import MarkupField
-
 from symposion.proposals.models import ProposalBase
 from symposion.conference.models import Section
 from symposion.speakers.models import Speaker
@@ -65,7 +63,7 @@ class Slot(models.Model):
     kind = models.ForeignKey(SlotKind)
     start = models.TimeField()
     end = models.TimeField()
-    content_override = MarkupField(blank=True)
+    content_override = models.TextField()
 
     def assign(self, content):
         """
@@ -150,8 +148,8 @@ class Presentation(models.Model):
 
     slot = models.OneToOneField(Slot, null=True, blank=True, related_name="content_ptr")
     title = models.CharField(max_length=100)
-    description = MarkupField()
-    abstract = MarkupField()
+    description = models.TextField()
+    abstract = models.TextField()
     speaker = models.ForeignKey(Speaker, related_name="presentations")
     additional_speakers = models.ManyToManyField(Speaker, related_name="copresentations",
                                                  blank=True)

--- a/symposion/speakers/models.py
+++ b/symposion/speakers/models.py
@@ -5,8 +5,6 @@ from django.core.urlresolvers import reverse
 
 from django.contrib.auth.models import User
 
-from markitup.fields import MarkupField
-
 
 class Speaker(models.Model):
 
@@ -18,10 +16,7 @@ class Speaker(models.Model):
     user = models.OneToOneField(User, null=True, related_name="speaker_profile")
     name = models.CharField(max_length=100, help_text=("As you would like it to appear in the "
                                                        "conference program."))
-    biography = MarkupField(blank=True, help_text=("A little bit about you.  Edit using "
-                                                   "<a href='http://warpedvisions.org/projects/"
-                                                   "markdown-cheat-sheet/target='_blank'>"
-                                                   "Markdown</a>."))
+    biography = models.TextField()
     photo = models.ImageField(upload_to="speaker_photos", blank=True)
     annotation = models.TextField()  # staff only
     invite_email = models.CharField(max_length=200, unique=True, null=True, db_index=True)


### PR DESCRIPTION
This PR replaces the Markdown fields with TextFields.  The markdown_parser.py was repeatedly throwing attribute errors.