### PR TITLE
Add language selector

### DIFF
--- a/symposion/conf.py
+++ b/symposion/conf.py
@@ -6,3 +6,4 @@ from appconf import AppConf
 class SymposionAppConf(AppConf):
 
     VOTE_THRESHOLD = 3
+    SHOW_LANGUAGE_SELECTOR = False

--- a/symposion/forms.py
+++ b/symposion/forms.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
 
 import account.forms
 
@@ -29,3 +31,19 @@ class SignupForm(account.forms.SignupForm):
                 raise forms.ValidationError(
                     "Email address must match previously typed email address")
         return email_confirm
+
+
+def get_language_choices():
+    # In settings, we had to mark the language names for translation using
+    # a dummy ugettext to avoid circular imports, so now we need to actually
+    # retrieve their translations
+    return [(value, _(name))
+            for value, name
+            in settings.LANGUAGES]
+
+
+class LanguageForm(forms.Form):
+    language = forms.ChoiceField(
+        choices=get_language_choices(),
+        help_text=_(u"Change language for this session")
+    )

--- a/symposion/views.py
+++ b/symposion/views.py
@@ -8,10 +8,9 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
 
 import account.views
-import constance
 
+from symposion.conf import settings
 import symposion.forms
-from symposion.forms import LanguageForm
 from symposion.proposals.models import ProposalSection
 
 class SignupView(account.views.SignupView):
@@ -58,8 +57,8 @@ def dashboard(request):
         return redirect("speaker_create_token",
                         request.session["pending-token"])
     context = {'proposals_are_open': bool(ProposalSection.available()), }
-    if constance.config.SHOW_LANGUAGE_SELECTOR:
-        context['language_form'] = LanguageForm(
+    if settings.SYMPOSION_SHOW_LANGUAGE_SELECTOR:
+        context['language_form'] = symposion.forms.LanguageForm(
             initial={'language': request.LANGUAGE_CODE})
     return render(
         request, "dashboard.html",
@@ -69,7 +68,7 @@ def dashboard(request):
 
 @require_POST
 def change_language(request):
-    form = LanguageForm(request.POST)
+    form = symposion.forms.LanguageForm(request.POST)
     if form.is_valid():
         request.session['django_language'] = form.cleaned_data['language']
     return redirect(request.POST['next'])

--- a/symposion/views.py
+++ b/symposion/views.py
@@ -5,11 +5,14 @@ from django.shortcuts import render, redirect
 
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.http import require_POST
 
 import account.views
+import constance
 
 import symposion.forms
-
+from symposion.forms import LanguageForm
+from symposion.proposals.models import ProposalSection
 
 class SignupView(account.views.SignupView):
 
@@ -54,4 +57,19 @@ def dashboard(request):
     if request.session.get("pending-token"):
         return redirect("speaker_create_token",
                         request.session["pending-token"])
-    return render(request, "dashboard.html")
+    context = {'proposals_are_open': bool(ProposalSection.available()), }
+    if constance.config.SHOW_LANGUAGE_SELECTOR:
+        context['language_form'] = LanguageForm(
+            initial={'language': request.LANGUAGE_CODE})
+    return render(
+        request, "dashboard.html",
+        context,
+    )
+
+
+@require_POST
+def change_language(request):
+    form = LanguageForm(request.POST)
+    if form.is_valid():
+        request.session['django_language'] = form.cleaned_data['language']
+    return redirect(request.POST['next'])

--- a/symposion/views.py
+++ b/symposion/views.py
@@ -13,6 +13,7 @@ from symposion.conf import settings
 import symposion.forms
 from symposion.proposals.models import ProposalSection
 
+
 class SignupView(account.views.SignupView):
 
     form_class = symposion.forms.SignupForm


### PR DESCRIPTION
feedback from pycon development with dropping dependency to constance.
Use AppConfig instead.

User who want to show language selector, add next line to `settings.py`:

```
SYMPOSION_SHOW_LANGUAGE_SELECTOR = True
```

Original commit:

```
commit 5bd3c600a3cdf20d8fcbfb50d3804779b890d0e0
Author: Dan Poirier <dpoirier@caktusgroup.com>
Date:   Fri Aug 9 07:58:10 2013 -0400

    Display language selector conditionally
    
    Add a constance setting that controls whether we display
    the language selector on the dashboard. Defaults to off.
    
    (Modify setting at /2014/admin/constance/config/)

commit 2e560f9ae6c1bf19dbae2037d7e554c535361333
Author: Dan Poirier <dpoirier@caktusgroup.com>
Date:   Thu Aug 8 10:19:32 2013 -0400

    Add language selector to dashboard
```