### PR TITLE
admin: show review result

### DIFF
--- a/symposion/reviews/admin.py
+++ b/symposion/reviews/admin.py
@@ -1,6 +1,18 @@
 from django.contrib import admin
 
-from symposion.reviews.models import NotificationTemplate
+from symposion.reviews.models import NotificationTemplate, ProposalResult
 
 
-admin.site.register(NotificationTemplate)
+admin.site.register(
+    NotificationTemplate,
+    list_display=[
+        'label',
+        'from_address',
+        'subject'
+    ]
+)
+
+admin.site.register(
+    ProposalResult,
+    list_display=['proposal', 'status', 'score', 'vote_count', 'accepted']
+)


### PR DESCRIPTION
feedback from pycon development.
'status' field is depend on #75 

this is a part from following:
```
commit 7305488c7268f7e215f81c4fa12c52e850fc687d
Author: Dan Poirier <dpoirier@caktusgroup.com>
Date:   Wed Jun 12 10:47:34 2013 -0400

    Start on tagging proposals
    
    * Add tags field to ProposalBase
    * Verify we can edit tags in the admin
    * Display a proposal's tags in the reviews table, also in the proposal
      details on the review page
    * Enable the reviews template context processor so we can navigate
      in the reviews area
    * Add a form on the Reviews page to edit proposal tags.
```

Signed-off-by: Hiroshi Miura <miurahr@linux.com>