### PR TITLE
admin can send email to sponsor contact from form

### DIFF
--- a/symposion/sponsorship/commands/create_sponsors_groups.py
+++ b/symposion/sponsorship/commands/create_sponsors_groups.py
@@ -1,0 +1,9 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Group
+from symposion.sponsorship.models import AUTH_GROUPS
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for group in AUTH_GROUPS:
+            Group.objects.get_or_create(name=group)

--- a/symposion/sponsorship/forms.py
+++ b/symposion/sponsorship/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.forms.models import inlineformset_factory, BaseInlineFormSet
+from django.utils.translation import ugettext_lazy as _
 
 from django.contrib.admin.widgets import AdminFileWidget
 
@@ -76,3 +77,15 @@ SponsorBenefitsFormSet = inlineformset_factory(
     can_delete=False, extra=0,
     fields=["text", "upload"]
 )
+
+
+class SponsorEmailForm(forms.Form):
+    from_ = forms.EmailField(widget=forms.TextInput(attrs={'class': 'fullwidth-input'}))
+    cc = forms.CharField(help_text=_(u"(comma-separated addresses)"),
+                         required=False,
+                         widget=forms.TextInput(attrs={'class': 'fullwidth-input'}))
+    bcc = forms.CharField(help_text=_(u"(comma-separated addresses)"),
+                          required=False,
+                          widget=forms.TextInput(attrs={'class': 'fullwidth-input'}))
+    subject = forms.CharField(widget=forms.TextInput(attrs={'class': 'fullwidth-input'}))
+    body = forms.CharField(widget=forms.Textarea(attrs={'class': 'fullwidth-textarea'}))

--- a/symposion/sponsorship/urls.py
+++ b/symposion/sponsorship/urls.py
@@ -8,4 +8,5 @@ urlpatterns = patterns(
     url(r"^apply/$", "sponsor_apply", name="sponsor_apply"),
     url(r"^add/$", "sponsor_add", name="sponsor_add"),
     url(r"^(?P<pk>\d+)/$", "sponsor_detail", name="sponsor_detail"),
+    url(r"^email/(?P<pks>[\d,]+)/$", "sponsor_email", name="sponsor_email"),
 )

--- a/symposion/sponsorship/views.py
+++ b/symposion/sponsorship/views.py
@@ -1,12 +1,19 @@
+from constance import config
+from django.core.mail import EmailMessage
+from django.core.urlresolvers import reverse
+
 from django.http import Http404
-from django.shortcuts import render_to_response, redirect, get_object_or_404
+from django.shortcuts import render_to_response, redirect, render, \
+    get_object_or_404
 from django.template import RequestContext
+from django.utils.translation import ugettext_lazy as _
 
 from django.contrib import messages
+from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 
-from symposion.sponsorship.forms import SponsorApplicationForm, SponsorDetailsForm, \
-    SponsorBenefitsFormSet
+from symposion.sponsorship.forms import SponsorApplicationForm, \
+    SponsorDetailsForm, SponsorBenefitsFormSet, SponsorEmailForm
 from symposion.sponsorship.models import Sponsor, SponsorBenefit
 
 
@@ -87,3 +94,60 @@ def sponsor_detail(request, pk):
         "form": form,
         "formset": formset,
     }, context_instance=RequestContext(request))
+
+
+@staff_member_required
+def sponsor_email(request, pks):
+    sponsors = Sponsor.objects.filter(pk__in=pks.split(","))
+
+    address_list = []
+    for sponsor in sponsors:
+        if sponsor.contact_email.lower() not in address_list:
+            address_list.append(sponsor.contact_email.lower())
+        if sponsor.applicant.email.lower() not in address_list:
+            address_list.append(sponsor.applicant.email.lower())
+
+    initial = {
+        'from_': config.SPONSOR_FROM_EMAIL,
+    }
+
+    # Note: on initial entry, we've got the request from the admin page,
+    # which was actually a POST, but not from our page. So be careful to
+    # check if it's a POST and it looks like our form.
+    if request.method == 'POST' and 'subject' in request.POST:
+        form = SponsorEmailForm(request.POST, initial=initial)
+        if form.is_valid():
+            data = form.cleaned_data
+
+            # Send emails one at a time, rendering the subject and
+            # body as templates.
+            for sponsor in sponsors:
+                address_list = []
+                if sponsor.contact_email.lower() not in address_list:
+                    address_list.append(sponsor.contact_email.lower())
+                if sponsor.applicant.email.lower() not in address_list:
+                    address_list.append(sponsor.applicant.email.lower())
+
+                subject = sponsor.render_email(data['subject'])
+                body = sponsor.render_email(data['body'])
+
+                mail = EmailMessage(
+                    subject=subject,
+                    body=body,
+                    from_email=data['from_'],
+                    to=address_list,
+                    cc=data['cc'].split(","),
+                    bcc=data['bcc'].split(",")
+                )
+                mail.send()
+            messages.add_message(request, messages.INFO, _(u"Email sent to sponsors"))
+            return redirect(reverse('admin:sponsorship_sponsor_changelist'))
+    else:
+        form = SponsorEmailForm(initial=initial)
+        context = {
+            'address_list': address_list,
+            'form': form,
+            'pks': pks,
+            'sponsors': sponsors,
+        }
+    return render(request, "sponsorship/email.html", context)


### PR DESCRIPTION
It is a part of feedback from PyCon development.
Here picks "email" action.

```
commit eb3261c12c910ec562e016f10431cc48747baef8
Author: Dan Poirier <dpoirier@caktusgroup.com>
Date:   Wed Aug 21 11:51:20 2013 -0400

    Enhanced sponsor admin page
    
    For #67:
    
    * admin list sorted by name
    * not limited to 100 per page
    * a sortable visual indicator for each sponsorship benefit (completed, missing, not applicable)
    * also the sponsorship level, admin contact name, and an active or not indication
    * the  ones we have today: print logo, web logo, print description, web description and the ad.
    * an action pick list like “email” and check mark the sponsors I want to email based on the assets that are missing.
    * in subject and body, replace %%NAME%% by sponsor name
```

Signed-off-by: Hiroshi Miura <miurahr@linux.com>