### PR TITLE
i18n sponsor fields

### DIFF
--- a/symposion/sponsorship/models.py
+++ b/symposion/sponsorship/models.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -144,9 +145,17 @@ post_save.connect(_check_level_change, sender=Sponsor)
 
 BENEFIT_TYPE_CHOICES = [
     ("text", "Text"),
+    ("richtext", "Rich Text"),
     ("file", "File"),
     ("weblogo", "Web Logo"),
-    ("simple", "Simple")
+    ("simple", "Simple"),
+    ("option", "Option")
+]
+
+CONTENT_TYPE_CHOICES = [
+    ("simple", "Simple"),
+] + [
+    ("listing_text_%s" % lang, "Listing Text (%s)" % label) for lang, label in settings.LANGUAGES
 ]
 
 
@@ -154,8 +163,10 @@ class Benefit(models.Model):
 
     name = models.CharField(_("name"), max_length=100)
     description = models.TextField(_("description"), blank=True)
-    type = models.CharField(_("type"), choices=BENEFIT_TYPE_CHOICES, max_length=10,
-                            default="simple")
+    type = models.CharField(_("type"), choices=BENEFIT_TYPE_CHOICES,
+                            max_length=10, default="simple")
+    content_type = models.CharField(_("content type"), choices=CONTENT_TYPE_CHOICES,
+                                    max_length=20, default="simple")
 
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
Feedback from PyConJP development

```
commit 5973e32ebdc231b209b5c058664e8b2b4a1dbc54
Author: MURAOKA Yusuke <yusuke@jbking.org>
Date:   Mon Mar 31 15:35:40 2014 +0900

    introduce Benefit.content_type which is used to display localized
    text

commit 28864a33583c11f6502d1f80e233599ea36b0848
Author: MURAOKA Yusuke <yusuke@jbking.org>
Date:   Mon Mar 31 14:01:52 2014 +0900

    introduce an invisible Benefit type, option to manage individual sponsor benefit not related to sponsor level

```

Signed-off-by: Hiroshi Miura <miurahr@linux.com>