### PR TITLE
distribute locale files in source and binary package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README LICENSE
 recursive-include symposion/templates *.html *.txt
 recursive-include symposion/static *
+recursive-include symposion/locale *


### PR DESCRIPTION
MANIFEST.in don't have a locale entry.
When installing symposion from pypi, locale files are not installed.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>