### PR TITLE
python3 compatibility

### DIFF
--- a/symposion/boxes/models.py
+++ b/symposion/boxes/models.py
@@ -1,11 +1,14 @@
+from __future__ import unicode_literals
 from django.db import models
 from django.contrib.auth.models import User
+from django.utils.encoding import python_2_unicode_compatible
 
 import reversion
 
 from markitup.fields import MarkupField
 
 
+@python_2_unicode_compatible
 class Box(models.Model):
 
     label = models.CharField(max_length=100, db_index=True)
@@ -14,7 +17,7 @@ class Box(models.Model):
     created_by = models.ForeignKey(User, related_name="boxes")
     last_updated_by = models.ForeignKey(User, related_name="updated_boxes")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
     class Meta:

--- a/symposion/cms/models.py
+++ b/symposion/cms/models.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from markitup.fields import MarkupField
@@ -17,6 +18,7 @@ import reversion
 from .managers import PublishedPageManager
 
 
+@python_2_unicode_compatible
 class Page(models.Model):
 
     STATUS_CHOICES = (
@@ -35,7 +37,7 @@ class Page(models.Model):
 
     published = PublishedPageManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
     @models.permalink

--- a/symposion/conference/apps.py
+++ b/symposion/conference/apps.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.apps import AppConfig
 
 

--- a/symposion/conference/models.py
+++ b/symposion/conference/models.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import python_2_unicode_compatible
 
 from timezones.fields import TimeZoneField
 
@@ -7,6 +9,7 @@ from timezones.fields import TimeZoneField
 CONFERENCE_CACHE = {}
 
 
+@python_2_unicode_compatible
 class Conference(models.Model):
     """
     the full conference for a specific year, e.g. US PyCon 2012.
@@ -21,7 +24,7 @@ class Conference(models.Model):
     # timezone the conference is in
     timezone = TimeZoneField(_("timezone"), blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
     def save(self, *args, **kwargs):
@@ -42,6 +45,7 @@ class Conference(models.Model):
         verbose_name_plural = _("conferences")
 
 
+@python_2_unicode_compatible
 class Section(models.Model):
     """
     a section of the conference such as "Tutorials", "Workshops",
@@ -58,8 +62,8 @@ class Section(models.Model):
     start_date = models.DateField(_("start date"), null=True, blank=True)
     end_date = models.DateField(_("end date"), null=True, blank=True)
 
-    def __unicode__(self):
-        return u"%s %s" % (self.conference, self.name)
+    def __str__(self):
+        return "%s %s" % (self.conference, self.name)
 
     class Meta(object):
         verbose_name = _("section")

--- a/symposion/markdown_parser.py
+++ b/symposion/markdown_parser.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from html5lib import html5parser, sanitizer
 
 import markdown

--- a/symposion/proposals/actions.py
+++ b/symposion/proposals/actions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import csv
 
 from django.http import HttpResponse

--- a/symposion/proposals/apps.py
+++ b/symposion/proposals/apps.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.apps import AppConfig
 
 

--- a/symposion/proposals/forms.py
+++ b/symposion/proposals/forms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django import forms
 from django.db.models import Q
 

--- a/symposion/proposals/models.py
+++ b/symposion/proposals/models.py
@@ -1,9 +1,11 @@
+from __future__ import unicode_literals
 import os
 import uuid
 
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import now
 
@@ -21,6 +23,7 @@ from symposion.conference.models import Section
 from symposion.speakers.models import Speaker
 
 
+@python_2_unicode_compatible
 class ProposalSection(models.Model):
     """
     configuration of proposal submissions for a specific Section.
@@ -55,10 +58,11 @@ class ProposalSection(models.Model):
             return False
         return True
 
-    def __unicode__(self):
+    def __str__(self):
         return self.section.name
 
 
+@python_2_unicode_compatible
 class ProposalKind(models.Model):
     """
     e.g. talk vs panel vs tutorial vs poster
@@ -72,10 +76,11 @@ class ProposalKind(models.Model):
     name = models.CharField(_("Name"), max_length=100)
     slug = models.SlugField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class ProposalBase(models.Model):
 
     objects = InheritanceManager()
@@ -155,9 +160,13 @@ class ProposalBase(models.Model):
             "kind": self.kind.name,
         }
 
+    def __str__(self):
+        return self.title
+
 reversion.register(ProposalBase)
 
 
+@python_2_unicode_compatible
 class AdditionalSpeaker(models.Model):
 
     SPEAKING_STATUS_PENDING = 1
@@ -177,7 +186,7 @@ class AdditionalSpeaker(models.Model):
     class Meta:
         unique_together = ("speaker", "proposalbase")
 
-    def __unicode__(self):
+    def __str__(self):
         if self.status is self.SPEAKING_STATUS_PENDING:
             return _(u"pending speaker (%s)") % self.speaker.email
         elif self.status is self.SPEAKING_STATUS_DECLINED:

--- a/symposion/proposals/views.py
+++ b/symposion/proposals/views.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import hashlib
 import random
 import sys

--- a/symposion/reviews/apps.py
+++ b/symposion/reviews/apps.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.apps import AppConfig
 
 

--- a/symposion/reviews/forms.py
+++ b/symposion/reviews/forms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django import forms
 
 from markitup.widgets import MarkItUpWidget

--- a/symposion/reviews/models.py
+++ b/symposion/reviews/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from datetime import datetime
 from decimal import Decimal
 
@@ -27,8 +28,8 @@ class ProposalScoreExpression(object):
 class Votes(object):
     PLUS_ONE = "+1"
     PLUS_ZERO = "+0"
-    MINUS_ZERO = u"−0"
-    MINUS_ONE = u"−1"
+    MINUS_ZERO = "−0"
+    MINUS_ONE = "−1"
 
     CHOICES = [
         (PLUS_ONE, u"+1 — Good proposal and I will argue for it to be accepted."),

--- a/symposion/reviews/utils.py
+++ b/symposion/reviews/utils.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 def has_permission(user, proposal, speaker=False, reviewer=False):
     """
     Returns whether or not ther user has permission to review this proposal,

--- a/symposion/schedule/admin.py
+++ b/symposion/schedule/admin.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.contrib import admin
 
 from symposion.schedule.models import Schedule, Day, Room, SlotKind, Slot, SlotRoom, Presentation, Session, SessionRole

--- a/symposion/schedule/apps.py
+++ b/symposion/schedule/apps.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.apps import AppConfig
 
 

--- a/symposion/schedule/forms.py
+++ b/symposion/schedule/forms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import csv
 import time
 

--- a/symposion/schedule/helpers.py
+++ b/symposion/schedule/helpers.py
@@ -2,6 +2,7 @@
 This file contains functions that are useful to humans at the shell for
 manipulating the database in more natural ways.
 """
+from __future__ import unicode_literals
 from django.db import transaction
 
 from .models import Schedule, Day, Room, Slot, SlotKind, SlotRoom

--- a/symposion/schedule/models.py
+++ b/symposion/schedule/models.py
@@ -1,8 +1,10 @@
+from __future__ import unicode_literals
 import datetime
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import User
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 from markitup.fields import MarkupField
 
@@ -11,42 +13,46 @@ from symposion.conference.models import Section
 from symposion.speakers.models import Speaker
 
 
+@python_2_unicode_compatible
 class Schedule(models.Model):
 
     section = models.OneToOneField(Section)
     published = models.BooleanField(default=True)
     hidden = models.BooleanField("Hide schedule from overall conference view", default=False)
 
-    def __unicode__(self):
-        return u"%s Schedule" % self.section
+    def __str__(self):
+        return "%s Schedule" % self.section
 
     class Meta:
         ordering = ["section"]
 
 
+@python_2_unicode_compatible
 class Day(models.Model):
 
     schedule = models.ForeignKey(Schedule)
     date = models.DateField()
 
-    def __unicode__(self):
-        return u"%s" % self.date
+    def __str__(self):
+        return "%s" % self.date
 
     class Meta:
         unique_together = [("schedule", "date")]
         ordering = ["date"]
 
 
+@python_2_unicode_compatible
 class Room(models.Model):
 
     schedule = models.ForeignKey(Schedule)
     name = models.CharField(max_length=65)
     order = models.PositiveIntegerField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class SlotKind(models.Model):
     """
     A slot kind represents what kind a slot is. For example, a slot can be a
@@ -56,10 +62,11 @@ class SlotKind(models.Model):
     schedule = models.ForeignKey(Schedule)
     label = models.CharField(max_length=50)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
 
+@python_2_unicode_compatible
 class Slot(models.Model):
 
     day = models.ForeignKey(Day)
@@ -124,14 +131,15 @@ class Slot(models.Model):
     def rooms(self):
         return Room.objects.filter(pk__in=self.slotroom_set.values("room"))
 
-    def __unicode__(self):
+    def __str__(self):
         roomlist = ' '.join(map(lambda r: r.__unicode__(), self.rooms))
-        return u"%s %s (%s - %s) %s" % (self.day, self.kind, self.start, self.end, roomlist)
+        return "%s %s (%s - %s) %s" % (self.day, self.kind, self.start, self.end, roomlist)
 
     class Meta:
         ordering = ["day", "start", "end"]
 
 
+@python_2_unicode_compatible
 class SlotRoom(models.Model):
     """
     Links a slot with a room.
@@ -140,14 +148,15 @@ class SlotRoom(models.Model):
     slot = models.ForeignKey(Slot)
     room = models.ForeignKey(Room)
 
-    def __unicode__(self):
-        return u"%s %s" % (self.room, self.slot)
+    def __str__(self):
+        return "%s %s" % (self.room, self.slot)
 
     class Meta:
         unique_together = [("slot", "room")]
         ordering = ["slot", "room__order"]
 
 
+@python_2_unicode_compatible
 class Presentation(models.Model):
 
     slot = models.OneToOneField(Slot, null=True, blank=True, related_name="content_ptr")
@@ -177,13 +186,14 @@ class Presentation(models.Model):
             if speaker.user:
                 yield speaker
 
-    def __unicode__(self):
-        return u"#%s %s (%s)" % (self.number, self.title, self.speaker)
+    def __str__(self):
+        return "#%s %s (%s)" % (self.number, self.title, self.speaker)
 
     class Meta:
         ordering = ["slot"]
 
 
+@python_2_unicode_compatible
 class Session(models.Model):
 
     day = models.ForeignKey(Day, related_name="sessions")
@@ -206,18 +216,19 @@ class Session(models.Model):
         else:
             return None
 
-    def __unicode__(self):
+    def __str__(self):
         start = self.start()
         end = self.end()
         if start and end:
-            return u"%s: %s - %s" % (
+            return "%s: %s - %s" % (
                 self.day.date.strftime("%a"),
                 start.strftime("%X"),
                 end.strftime("%X")
             )
-        return u""
+        return ""
 
 
+@python_2_unicode_compatible
 class SessionRole(models.Model):
 
     SESSION_ROLE_CHAIR = 1
@@ -238,6 +249,6 @@ class SessionRole(models.Model):
     class Meta:
         unique_together = [("session", "user", "role")]
 
-    def __unicode__(self):
-        return u"%s %s: %s" % (self.user, self.session,
-                               self.SESSION_ROLE_TYPES[self.role - 1][1])
+    def __str__(self):
+        return "%s %s: %s" % (self.user, self.session,
+                              self.SESSION_ROLE_TYPES[self.role - 1][1])

--- a/symposion/schedule/timetable.py
+++ b/symposion/schedule/timetable.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import itertools
 
 from django.db.models import Count, Min

--- a/symposion/schedule/urls.py
+++ b/symposion/schedule/urls.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.conf.urls import url, patterns
 
 

--- a/symposion/schedule/views.py
+++ b/symposion/schedule/views.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 
 from django.core.urlresolvers import reverse

--- a/symposion/speakers/admin.py
+++ b/symposion/speakers/admin.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.contrib import admin
 
 from symposion.speakers.models import Speaker

--- a/symposion/speakers/apps.py
+++ b/symposion/speakers/apps.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.apps import AppConfig
 
 

--- a/symposion/speakers/forms.py
+++ b/symposion/speakers/forms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django import forms
 
 from markitup.widgets import MarkItUpWidget

--- a/symposion/speakers/models.py
+++ b/symposion/speakers/models.py
@@ -1,4 +1,6 @@
+from __future__ import unicode_literals
 import datetime
+from django.utils.encoding import python_2_unicode_compatible
 
 from django.db import models
 from django.core.urlresolvers import reverse
@@ -8,6 +10,7 @@ from django.contrib.auth.models import User
 from markitup.fields import MarkupField
 
 
+@python_2_unicode_compatible
 class Speaker(models.Model):
 
     SESSION_COUNT_CHOICES = [
@@ -34,11 +37,11 @@ class Speaker(models.Model):
     class Meta:
         ordering = ['name']
 
-    def __unicode__(self):
+    def __str__(self):
         if self.user:
             return self.name
         else:
-            return u"?"
+            return "?"
 
     def get_absolute_url(self):
         return reverse("speaker_edit")

--- a/symposion/speakers/urls.py
+++ b/symposion/speakers/urls.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.conf.urls import patterns, url
 
 

--- a/symposion/speakers/views.py
+++ b/symposion/speakers/views.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.shortcuts import render, redirect, get_object_or_404

--- a/symposion/sponsorship/admin.py
+++ b/symposion/sponsorship/admin.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.contrib import admin
 from django.utils.html import escape
 from django.utils.safestring import mark_safe

--- a/symposion/sponsorship/forms.py
+++ b/symposion/sponsorship/forms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django import forms
 from django.forms.models import inlineformset_factory, BaseInlineFormSet
 

--- a/symposion/sponsorship/models.py
+++ b/symposion/sponsorship/models.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 
 from django.conf import settings
@@ -5,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models.signals import post_init, post_save
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from django.contrib.auth.models import User
@@ -14,6 +16,7 @@ from symposion.conference.models import Conference
 from symposion.sponsorship.managers import SponsorManager
 
 
+@python_2_unicode_compatible
 class SponsorLevel(models.Model):
 
     conference = models.ForeignKey(Conference, verbose_name=_("conference"))
@@ -27,13 +30,14 @@ class SponsorLevel(models.Model):
         verbose_name = _("sponsor level")
         verbose_name_plural = _("sponsor levels")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def sponsors(self):
         return self.sponsor_set.filter(active=True).order_by("added")
 
 
+@python_2_unicode_compatible
 class Sponsor(models.Model):
 
     applicant = models.ForeignKey(User, related_name="sponsorships", verbose_name=_("applicant"),
@@ -55,7 +59,7 @@ class Sponsor(models.Model):
 
     objects = SponsorManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta:
@@ -166,6 +170,7 @@ CONTENT_TYPE_CHOICES = [
 ]
 
 
+@python_2_unicode_compatible
 class Benefit(models.Model):
 
     name = models.CharField(_("name"), max_length=100)
@@ -175,10 +180,11 @@ class Benefit(models.Model):
     content_type = models.CharField(_("content type"), choices=CONTENT_TYPE_CHOICES,
                                     max_length=20, default="simple")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class BenefitLevel(models.Model):
 
     benefit = models.ForeignKey(Benefit, related_name="benefit_levels", verbose_name=_("benefit"))
@@ -191,10 +197,11 @@ class BenefitLevel(models.Model):
     class Meta:
         ordering = ["level"]
 
-    def __unicode__(self):
-        return u"%s - %s" % (self.level, self.benefit)
+    def __str__(self):
+        return "%s - %s" % (self.level, self.benefit)
 
 
+@python_2_unicode_compatible
 class SponsorBenefit(models.Model):
 
     sponsor = models.ForeignKey(Sponsor, related_name="sponsor_benefits", verbose_name=_("sponsor"))
@@ -213,8 +220,8 @@ class SponsorBenefit(models.Model):
     class Meta:
         ordering = ["-active"]
 
-    def __unicode__(self):
-        return u"%s - %s" % (self.sponsor, self.benefit)
+    def __str__(self):
+        return "%s - %s" % (self.sponsor, self.benefit)
 
     def clean(self):
         num_words = len(self.text.split())

--- a/symposion/sponsorship/views.py
+++ b/symposion/sponsorship/views.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from cStringIO import StringIO
 import itertools
 import logging

--- a/symposion/teams/forms.py
+++ b/symposion/teams/forms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django import forms
 
 from django.utils.html import escape

--- a/symposion/teams/models.py
+++ b/symposion/teams/models.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 
 from django.db import models
@@ -5,6 +6,7 @@ from django.db import models
 import reversion
 
 from django.contrib.auth.models import Permission, User
+from django.utils.encoding import python_2_unicode_compatible
 
 
 TEAM_ACCESS_CHOICES = [
@@ -14,6 +16,7 @@ TEAM_ACCESS_CHOICES = [
 ]
 
 
+@python_2_unicode_compatible
 class Team(models.Model):
 
     slug = models.SlugField(unique=True)
@@ -34,7 +37,7 @@ class Team(models.Model):
     def get_absolute_url(self):
         return ("team_detail", [self.slug])
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def get_state_for_user(self, user):

--- a/symposion/teams/views.py
+++ b/symposion/teams/views.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.http import Http404, HttpResponseNotAllowed
 from django.shortcuts import render, redirect, get_object_or_404
 

--- a/symposion/views.py
+++ b/symposion/views.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import hashlib
 import random
 


### PR DESCRIPTION
- Things are suggested in python3 porting guide.
https://docs.djangoproject.com/en/1.8/topics/python3/

     1. adding ```from django.utils.encoding import
     python_2_unicode_compatible```

     2. ``` __str__``` instead of ```__unicode__```
     https://docs.djangoproject.com/en/1.8/topics/python3/#str-and-unicode-methods

     3. Adding ```from __future__ import unicode_literals``` at the top
     of your Python modules
     https://docs.djangoproject.com/en/1.8/topics/python3/#unicode-literals

     4. Removing the `u` prefix before unicode strings;
     https://docs.djangoproject.com/en/1.8/topics/python3/#unicode-literals

- also closed #66

Signed-off-by: Hiroshi Miura <miurahr@linux.com>