### PR TITLE
reorder signup fields

### DIFF
--- a/symposion/forms.py
+++ b/symposion/forms.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from django import forms
 
 import account.forms
@@ -12,7 +14,7 @@ class SignupForm(account.forms.SignupForm):
     def __init__(self, *args, **kwargs):
         super(SignupForm, self).__init__(*args, **kwargs)
         del self.fields["username"]
-        self.fields.keyOrder = [
+        key_order = [
             "email",
             "email_confirm",
             "first_name",
@@ -20,6 +22,7 @@ class SignupForm(account.forms.SignupForm):
             "password",
             "password_confirm"
         ]
+        self.fields = reorder_fields(self.fields, key_order)
 
     def clean_email_confirm(self):
         email = self.cleaned_data.get("email")
@@ -29,3 +32,18 @@ class SignupForm(account.forms.SignupForm):
                 raise forms.ValidationError(
                     "Email address must match previously typed email address")
         return email_confirm
+
+
+def reorder_fields(fields, order):
+    """Reorder form fields by order, removing items not in order.
+
+    >>> reorder_fields(
+    ...     OrderedDict([('a', 1), ('b', 2), ('c', 3)]),
+    ...     ['b', 'c', 'a'])
+    OrderedDict([('b', 2), ('c', 3), ('a', 1)])
+    """
+    for key, v in fields.items():
+        if key not in order:
+            del fields[key]
+
+    return OrderedDict(sorted(fields.items(), key=lambda k: order.index(k[0])))

--- a/symposion/forms.py
+++ b/symposion/forms.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django import forms
+from django import VERSION as django_VERSION
 
 import account.forms
 
@@ -13,7 +14,6 @@ class SignupForm(account.forms.SignupForm):
 
     def __init__(self, *args, **kwargs):
         super(SignupForm, self).__init__(*args, **kwargs)
-        del self.fields["username"]
         key_order = [
             "email",
             "email_confirm",
@@ -46,4 +46,10 @@ def reorder_fields(fields, order):
         if key not in order:
             del fields[key]
 
-    return OrderedDict(sorted(fields.items(), key=lambda k: order.index(k[0])))
+    if django_VERSION < (1, 7, 0):
+        # fields is SortedDict
+        fields.keyOrder.sort(key=lambda k: order.index(k[0]))
+        return fields
+    else:
+        # fields is OrderedDict
+        return OrderedDict(sorted(fields.items(), key=lambda k: order.index(k[0])))

--- a/symposion/forms.py
+++ b/symposion/forms.py
@@ -1,7 +1,9 @@
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    OrderedDict = None
 
 from django import forms
-from django import VERSION as django_VERSION
 
 import account.forms
 
@@ -46,7 +48,7 @@ def reorder_fields(fields, order):
         if key not in order:
             del fields[key]
 
-    if django_VERSION < (1, 7, 0):
+    if not OrderedDict or hasattr(fields, "keyOrder"):
         # fields is SortedDict
         fields.keyOrder.sort(key=lambda k: order.index(k[0]))
         return fields


### PR DESCRIPTION
A current implementation for ordering form is not work on Django 1.7+ anymore. 
It activate a feature in Django 1.7+ and drop support for Django 1.6 and before.

Closed: #102 
Signed-off-by: Hiroshi Miura <miurahr@linux.com>