### PR TITLE
Inline schedule edit for admin

### DIFF
--- a/symposion/conference/admin.py
+++ b/symposion/conference/admin.py
@@ -3,7 +3,18 @@ from django.contrib import admin
 from symposion.conference.models import Conference, Section
 
 
-admin.site.register(Conference, list_display=("title", "start_date", "end_date"))
+class SectionInline(admin.TabularInline):
+    model = Section
+    prepopulated_fields = {"slug": ("name",)}
+    extra = 1
+
+
+class ConferenceAdmin(admin.ModelAdmin):
+    list_display = ("title", "start_date", "end_date")
+    inlines = [SectionInline, ]
+
+
+admin.site.register(Conference, ConferenceAdmin)
 admin.site.register(
     Section,
     prepopulated_fields={"slug": ("name",)},

--- a/symposion/schedule/admin.py
+++ b/symposion/schedule/admin.py
@@ -3,18 +3,43 @@ from django.contrib import admin
 from symposion.schedule.models import Schedule, Day, Room, SlotKind, Slot, SlotRoom, Presentation, Session, SessionRole
 
 
-admin.site.register(Schedule)
-admin.site.register(Day)
-admin.site.register(Room)
-admin.site.register(SlotKind)
-admin.site.register(
-    Slot,
-    list_display=("day", "start", "end", "kind")
-)
-admin.site.register(
-    SlotRoom,
-    list_display=("slot", "room")
-)
+class DayInline(admin.StackedInline):
+    model = Day
+    extra = 2
+
+
+class SlotKindInline(admin.StackedInline):
+    model = SlotKind
+
+
+class ScheduleAdmin(admin.ModelAdmin):
+    model = Schedule
+    inlines = [DayInline, SlotKindInline, ]
+
+
+class SlotRoomInline(admin.TabularInline):
+    model = SlotRoom
+    extra = 1
+
+
+class SlotAdmin(admin.ModelAdmin):
+    list_filter = ("day", "kind")
+    list_display = ("day", "start", "end", "kind", "content")
+    inlines = [SlotRoomInline, ]
+
+
+class RoomAdmin(admin.ModelAdmin):
+    inlines = [SlotRoomInline, ]
+
+
+class PresentationAdmin(admin.ModelAdmin):
+    model = Presentation
+    list_filter = ("section", "cancelled", "slot")
+
+
+admin.site.register(Schedule, ScheduleAdmin)
+admin.site.register(Room, RoomAdmin)
+admin.site.register(Slot, SlotAdmin)
 admin.site.register(Session)
 admin.site.register(SessionRole)
-admin.site.register(Presentation)
+admin.site.register(Presentation, PresentationAdmin)


### PR DESCRIPTION
There is a complex schedule related models.
This PR reduce admin menu and help administrator to setup conference.

- configure `section` with `conference` in same time
- configure `day` and 'kind' with `schedule` in same time
- edit 'slot' and 'room' in same time