### PR TITLE
Replace django-timezones w/ django-timezone-field

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ django-model-utils==2.2
 django-reversion==1.8.5
 django-sitetree==1.2.1
 django-taggit==0.12.2
-django-timezones==0.2
+django-timezone-field==1.2
 django-user-accounts==1.0
 easy-thumbnails==2.2
 html5lib==0.999

--- a/symposion/conference/models.py
+++ b/symposion/conference/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from timezones.fields import TimeZoneField
+from timezone_field import TimeZoneField
 
 
 CONFERENCE_CACHE = {}
@@ -19,7 +19,7 @@ class Conference(models.Model):
     end_date = models.DateField(_("end date"), null=True, blank=True)
 
     # timezone the conference is in
-    timezone = TimeZoneField(_("timezone"), blank=True)
+    timezone = TimeZoneField(blank=True, verbose_name=_("timezone"))
 
     def __unicode__(self):
         return self.title


### PR DESCRIPTION
django-timezones does not support Python 3. django-timezone-field is
a revived fork that does.

Ref #100.