### PR TITLE
Loosen Django package requirement.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.8.5
+Django>=1.8.5
 django-appconf==1.0.1
 django-model-utils==2.3.1
 django-reversion==1.9.3


### PR DESCRIPTION
Loosen Django requirement to allow versions greater or equal to 1.8.5,
instead of mandating 1.8.5. This makes it easier to use newer releases
of Django (e.g. the bugfix and security releases 1.8.6 or 1.8.7) with
symposion.