### PR TITLE
Remove duplicate Slot.save method.

### DIFF
--- a/symposion/schedule/models.py
+++ b/symposion/schedule/models.py
@@ -90,10 +90,6 @@ class Slot(models.Model):
     content_override = models.TextField(blank=True, verbose_name=_("Content override"))
     content_override_html = models.TextField(blank=True)
 
-    def save(self, *args, **kwargs):
-        self.content_override_html = parse(self.content_override)
-        return super(Slot, self).save(*args, **kwargs)
-
     def assign(self, content):
         """
         Assign the given content to this slot and if a previous slot content


### PR DESCRIPTION
Remove "save" method in Slot model since #107 added another "save"
method. This fixes the automated test failures in Travis CI.