### PR TITLE
Make sponsor description default empty string.

### DIFF
--- a/symposion/sponsorship/models.py
+++ b/symposion/sponsorship/models.py
@@ -136,7 +136,7 @@ class Sponsor(models.Model):
     @property
     def listing_text(self):
         if not hasattr(self, "_listing_text"):
-            self._listing_text = None
+            self._listing_text = ""
             # @@@ better than hard-coding a pk but still not good
             benefits = self.sponsor_benefits.filter(benefit__name="Sponsor Description")
             if benefits.count():


### PR DESCRIPTION
Set sponsor listing text to an empty string instead of None. If a
sponsor doesn't have a benefit named "Sponsor Description", this will
prevent the text "None" from displaying in the Django template.