### PR TITLE
Don't show unpublished schedule info to non-staff.

### DIFF
--- a/symposion/schedule/views.py
+++ b/symposion/schedule/views.py
@@ -69,6 +69,8 @@ def schedule_detail(request, slug=None):
 
 def schedule_list(request, slug=None):
     schedule = fetch_schedule(slug)
+    if not schedule.published and not request.user.is_staff:
+        raise Http404()
 
     presentations = Presentation.objects.filter(section=schedule.section)
     presentations = presentations.exclude(cancelled=True)
@@ -82,6 +84,8 @@ def schedule_list(request, slug=None):
 
 def schedule_list_csv(request, slug=None):
     schedule = fetch_schedule(slug)
+    if not schedule.published and not request.user.is_staff:
+        raise Http404()
 
     presentations = Presentation.objects.filter(section=schedule.section)
     presentations = presentations.exclude(cancelled=True).order_by("id")
@@ -169,6 +173,8 @@ def schedule_presentation_detail(request, pk):
     presentation = get_object_or_404(Presentation, pk=pk)
     if presentation.slot:
         schedule = presentation.slot.day.schedule
+        if not schedule.published and not request.user.is_staff:
+            raise Http404()
     else:
         schedule = None
 


### PR DESCRIPTION
Add checks to `schedule_list`, `schedule_list_csv`, and
`schedule_presentation_detail` views to verify that either schedule is
published or that current user is staff before displaying information.

c7592bc33e2626d84ec46fe1e7ba8e05c73ef74c added a similar check for `schedule_detail`, but not the other schedule-related views.