### PR TITLE
Add missing migration for schedule slot model.

### DIFF
--- a/symposion/schedule/migrations/0002_slot_name.py
+++ b/symposion/schedule/migrations/0002_slot_name.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def resave_slots(apps, schema_editor):
+    ScheduleSlot = apps.get_model("symposion_schedule", "slot")
+    for slot in ScheduleSlot.objects.all():
+        slot.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('symposion_schedule', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='slot',
+            name='name',
+            field=models.CharField(default='', max_length=100, editable=False),
+            preserve_default=False,
+        ),
+        migrations.RunPython(resave_slots, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
c0402575475e481d9d4dfdc64bf6f9e0cf90ad2b added a "name" field to
schedule slots. At the time it was written, symposion did not include
migrations. This commit creates a migration that adds the field to the
database table and automates the generation of the slot name (by re-saving
all existing slots).

This fixes a database error that happens when accessing schedule slots:

````
ProgrammingError: column symposion_schedule_slot.name does not exist
LINE 1: SELECT "symposion_schedule_slot"."id", "symposion_schedule_s...
````