### PR TITLE
Fix queryset used in "Not Reviewed" view.

### DIFF
--- a/symposion/reviews/views.py
+++ b/symposion/reviews/views.py
@@ -87,7 +87,8 @@ def review_section(request, section_slug, assigned=False, reviewed="all"):
         queryset = queryset.filter(reviews__user=request.user)
         reviewed = "user_reviewed"
     else:
-        queryset = queryset.exclude(reviews__user=request.user).exclude(speaker=request.user)
+        queryset = queryset.exclude(reviews__user=request.user).exclude(
+            speaker__user=request.user)
         reviewed = "user_not_reviewed"
 
     proposals = proposals_generator(request, queryset)


### PR DESCRIPTION
The `speaker` field on the `Proposal` model corresponds to a `Speaker`,
not a `User`, so the old queryset created a ValueError when accessing
the list of unreviewed proposals.