### PR TITLE
Display content_override in slot admin list view.

### DIFF
--- a/symposion/schedule/admin.py
+++ b/symposion/schedule/admin.py
@@ -25,7 +25,7 @@ class SlotRoomInline(admin.TabularInline):
 
 class SlotAdmin(admin.ModelAdmin):
     list_filter = ("day", "kind")
-    list_display = ("day", "start", "end", "kind", "content")
+    list_display = ("day", "start", "end", "kind", "content_override")
     inlines = [SlotRoomInline]
 
 


### PR DESCRIPTION
Fix typo and use `content_override` field (instead of `content`) for a
Slot's `list_display`.