### PR TITLE
Adds documentation pointing users at Registrasion

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,6 @@ Pinax Symposion is an open-source conference management system written in
 Django.  Symposion includes support for content management, proposal
 submission, reviews, scheduling and sponsor management.
 
-
 .. toctree::
    :maxdepth: 2
 
@@ -25,10 +24,18 @@ Symposion came out of development done by Eldarion for DjangoCon US and US PyCon
 but has been independently used for a number of other conferences.
 The project homepage is http://eldarion.com/symposion/
 
+Registration
+~~~~~~~~~~~~
+
+Symposion does not include support for conference registration. An independent
+project, Registrasion, can be used to add conference registration features to
+your Symposion site. Registrasion can be found at
+http://github.com/chrisjrn/registrasion
+
+
 Indices and tables
 ==================
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-


### PR DESCRIPTION
Adds documentation mentioning Registrasion as an option for conference registration. This should close #117.