### PR TITLE
Fixes error in delete

### DIFF
--- a/symposion/reviews/views.py
+++ b/symposion/reviews/views.py
@@ -290,7 +290,7 @@ def review_detail(request, pk):
 @require_POST
 def review_delete(request, pk):
     review = get_object_or_404(Review, pk=pk)
-    section_slug = review.section.slug
+    section_slug = review.section
 
     if not request.user.has_perm("reviews.can_manage_%s" % section_slug):
         return access_not_permitted(request)


### PR DESCRIPTION
`review.section` is a slug itself, so the review_delete would previously 500 rather than deleting comments

Fixes #135 