### PR TITLE
Replaces update_vote with a direct calculation from the database

### DIFF
--- a/symposion/reviews/models.py
+++ b/symposion/reviews/models.py
@@ -262,7 +262,7 @@ class ProposalResult(models.Model):
             vote_count[d["vote"]] = d["count"]
 
         self.plus_one = vote_count[VOTES.PLUS_ONE]
-        self.plus_zero = vote_count[VOTES.PLUS_ZEO]
+        self.plus_zero = vote_count[VOTES.PLUS_ZERO]
         self.minus_zero = vote_count[VOTES.MINUS_ZERO]
         self.minus_one = vote_count[VOTES.MINUS_ONE]
         self.vote_count = sum(i[1] for i in vote_count.items())


### PR DESCRIPTION
Fixes #137. The previous `update_vote` broke severely on deletion. This optimises the queries done in `full_calculate` (to use a single `annotate`) and makes `update_vote` use the inner query of `full_calculate`. Far less weird, far more working.
