### PR TITLE
Make timetable work with sessions that span more than one slot.

### DIFF
--- a/symposion/schedule/timetable.py
+++ b/symposion/schedule/timetable.py
@@ -42,7 +42,7 @@ class TimeTable(object):
 
     @staticmethod
     def rowspan(times, start, end):
-        return times.index(end) - times.index(start)
+        return max(1, (times.index(end) - times.index(start))/2)
 
 
 def pairwise(iterable):


### PR DESCRIPTION
Imagine a conference with several rooms, some of which hold short talks, others hold longer tutorials. Currently, the timetable doesn't render correctly, since the rowspan calculation (symposion/schedule/timetable.py):

```python
    @staticmethod
    def rowspan(times, start, end):
        return times.index(end) - times.index(start)
```

is incorrect: 'times' contains both start and end times, so this only returns the correct value of the slot being calculates does not span more than one other slot. The fix is:

```python
    @staticmethod
    def rowspan(times, start, end):
        return max(1, (times.index(end) - times.index(start))/2)
```

Without this fix, the schedule renders as:

![ewww](http://static.inky.ws/image/5819/schedule_broken.png)

With the fix, the schedule renders correctly:

![ahhhh](http://static.inky.ws/image/5818/schedule_fixed.png)