### PR TITLE
Patch 3

### DIFF
--- a/symposion/utils/mail.py
+++ b/symposion/utils/mail.py
@@ -53,11 +53,6 @@ def __send_email__(template_prefix, to, kind, **kwargs):
 
     from_email = settings.DEFAULT_FROM_EMAIL
 
-    try:
-        bcc_email = settings.ENVELOPE_BCC_LIST
-    except AttributeError:
-        bcc_email = None
-
-    email = EmailMultiAlternatives(subject, message_plaintext, from_email, to, bcc=bcc_email)
+    email = EmailMultiAlternatives(subject, message_plaintext, from_email, to)
     email.attach_alternative(message_html, "text/html")
     email.send()

--- a/symposion/utils/mail.py
+++ b/symposion/utils/mail.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
@@ -6,7 +8,31 @@ from django.utils.html import strip_tags
 from django.contrib.sites.models import Site
 
 
-def send_email(to, kind, **kwargs):
+class Sender(object):
+    ''' Class for sending e-mails under a templete prefix. '''
+
+    def __init__(self, template_prefix):
+        self.template_prefix = template_prefix
+
+    def send_email(self, to, kind, **kwargs):
+        ''' Sends an e-mail to the given address.
+
+        to: The address
+        kind: the ID for an e-mail kind; it should point to a subdirectory of
+            self.template_prefix containing subject.txt and message.html, which
+            are django templates for the subject and HTML message respectively.
+
+        context: a context for rendering the e-mail.
+
+        '''
+
+        return __send_email__(self.template_prefix, to, kind, **kwargs)
+
+
+send_email = Sender("symposion/emails").send_email
+
+
+def __send_email__(template_prefix, to, kind, **kwargs):
 
     current_site = Site.objects.get_current()
 
@@ -15,16 +41,23 @@ def send_email(to, kind, **kwargs):
         "STATIC_URL": settings.STATIC_URL,
     }
     ctx.update(kwargs.get("context", {}))
+    subject_template = os.path.join(template_prefix, "%s/subject.txt" % kind)
+    message_template = os.path.join(template_prefix, "%s/message.html" % kind)
     subject = "[%s] %s" % (
         current_site.name,
-        render_to_string("symposion/emails/%s/subject.txt" % kind, ctx).strip()
+        render_to_string(subject_template, ctx).strip()
     )
 
-    message_html = render_to_string("symposion/emails/%s/message.html" % kind, ctx)
+    message_html = render_to_string(message_template, ctx)
     message_plaintext = strip_tags(message_html)
 
     from_email = settings.DEFAULT_FROM_EMAIL
 
-    email = EmailMultiAlternatives(subject, message_plaintext, from_email, to)
+    try:
+        bcc_email = settings.ENVELOPE_BCC_LIST
+    except AttributeError:
+        bcc_email = None
+
+    email = EmailMultiAlternatives(subject, message_plaintext, from_email, to, bcc=bcc_email)
     email.attach_alternative(message_html, "text/html")
     email.send()


### PR DESCRIPTION
I wanted to re-use symposion's e-mail sending framework, but the process it adopts is very very fixed to Symposion.

Here's a minimal-churn version of a fix that allows you to specify the template prefix for your mailing function.