### PR TITLE
Fix ambiguity in schedule.urls #148

### DIFF
--- a/symposion/schedule/urls.py
+++ b/symposion/schedule/urls.py
@@ -28,6 +28,6 @@ urlpatterns = [
     url(r"^([\w\-]+)/edit/slot/(\d+)/", schedule_slot_edit, name="schedule_slot_edit"),
     url(r"^conference.json", schedule_json, name="schedule_json"),
     url(r"^sessions/staff.txt$", session_staff_email, name="schedule_session_staff_email"),
-    url(r"^sessions/$", session_list, name="schedule_session_list"),
+    url(r"^sessions/all/$", session_list, name="schedule_session_list"),
     url(r"^session/(\d+)/$", session_detail, name="schedule_session_detail"),
 ]


### PR DESCRIPTION
r"^sessions/$" was changed to r"^sessions/all/$" for the purpose of avoiding a conflict with r"^([\w\-]+)/$".
It raised "Page not found" (404) error.

Fixes #148