### PR TITLE
Make logoless sponsors not cause an error.

### DIFF
--- a/symposion/sponsorship/models.py
+++ b/symposion/sponsorship/models.py
@@ -131,7 +131,8 @@ class Sponsor(models.Model):
                 if benefits[0].upload:
                     self.sponsor_logo = benefits[0]
                     self.save()
-        return self.sponsor_logo.upload
+        if self.sponsor_logo:
+            return self.sponsor_logo.upload
 
     @property
     def listing_text(self):


### PR DESCRIPTION
If a sponsor does not have a logo, the website_logo method would still
try to return the non-existent logo's upload attribute. This commit
modifies the method so that nothing is returned if the sponsor does not
have a logo.