### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Here is an example of these rules applied:
 ## Pull Requests
 
 Please keep your pull requests focused on one specific thing only. If you
-have a number of contributions to make, then please send seperate pull
+have a number of contributions to make, then please send separate pull
 requests. It is much easier on maintainers to receive small, well defined,
 pull requests, than it is to have a single large one that batches up a
 lot of unrelated commits.

--- a/symposion/reviews/utils.py
+++ b/symposion/reviews/utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 def has_permission(user, proposal, speaker=False, reviewer=False):
     """
-    Returns whether or not ther user has permission to review this proposal,
+    Returns whether or not there user has permission to review this proposal,
     with the specified requirements.
 
     If ``speaker`` is ``True`` then the user can be one of the speakers for the

--- a/symposion/sponsorship/models.py
+++ b/symposion/sponsorship/models.py
@@ -87,7 +87,7 @@ class Sponsor(models.Model):
                                      editable=False, verbose_name=_("Sponsor logo"))
 
     # Whether things are complete
-    # True = complete, False = incomplate, Null = n/a for this sponsor level
+    # True = complete, False = incomplete, Null = n/a for this sponsor level
     web_logo_benefit = models.NullBooleanField(_("Web logo benefit"), help_text=_(u"Web logo benefit is complete"))
     print_logo_benefit = models.NullBooleanField(_("Print logo benefit"), help_text=_(u"Print logo benefit is complete"))
     print_description_benefit = models.NullBooleanField(_("Print description benefit"), help_text=_(u"Print description benefit is complete"))

--- a/symposion/static/tabletools/js/TableTools.js
+++ b/symposion/static/tabletools/js/TableTools.js
@@ -208,7 +208,7 @@ TableTools = function( oDT, oOpts )
 		
 		/**
 		 * Tag names that are used for creating collections and buttons
-		 *  @namesapce
+		 *  @namespace
 		 */
 		"tags": {}
 	};


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- symposion/reviews/utils.py
- symposion/sponsorship/models.py
- symposion/static/tabletools/js/TableTools.js

Fixes:
- Should read `there` rather than `ther`.
- Should read `separate` rather than `seperate`.
- Should read `namespace` rather than `namesapce`.
- Should read `incomplete` rather than `incomplate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md